### PR TITLE
Correct dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "homepage": "https://github.com/lisb/hubot-direct",
   "dependencies": {
     "direct-js": "^1.101.1"
+  },
+  "peerDependencies": {
+    "lisb-hubot": "^3.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-direct",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Direct adapter for GitHub's Hubot",
   "main": "./src/direct",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "direct-js": "^1.101.1"
   },
   "peerDependencies": {
-    "lisb-hubot": "^3.3.2"
+    "lisb-hubot": ">=3 <10 || 0.0.0-development"
   }
 }

--- a/src/direct.coffee
+++ b/src/direct.coffee
@@ -10,11 +10,7 @@ ws_config = try JSON.parse(process.env.HUBOT_DIRECT_WS_CONFIG)
 offline = process.env.HUBOT_DIRECT_OFFLINE
 initTimeout = Number(process.env.HUBOT_DIRECT_INIT_TIMEOUT) or 0 #s
 
-# Hubot dependencies
-try
-  hubot = require 'lisb-hubot'
-catch
-  hubot = require 'hubot'
+hubot = require.main.require 'lisb-hubot'
 {Robot,Adapter,TextMessage,EnterMessage,LeaveMessage,JoinMessage,TopicMessage} = hubot
 
 # dependencies


### PR DESCRIPTION
`lisb/hubot` に存在する direct 固有コードの移植は別 PR を予定