### PR TITLE
fix: Construct an envelope object correctly

### DIFF
--- a/src/direct.coffee
+++ b/src/direct.coffee
@@ -90,7 +90,7 @@ class Direct extends Adapter
 
    withAuthor = (callback) ->
      (talk, user, msg) ->
-       envelope = bot.userForId(user.id)
+       envelope = {}
        envelope[key] = value for key,value of user
        envelope[key] = value for key,value of talk
        callback envelope, msg


### PR DESCRIPTION
所属組織を考慮しない補完処理である `bot.userForId(user.id)` を削除します．そもそも direct-js から渡される `user` に必要な情報が入っているため，不要です．